### PR TITLE
Remove the greenlet dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         'six',
 		'zope.interface',
 		'gevent',
-		'greenlet',
 	],
 	setup_requires = [
 		# Without this, we don't get data files in sdist,


### PR DESCRIPTION
It is not explicitly used here. Previously it was wrong beacuse PyPy ships its own.

Fixes #3